### PR TITLE
Fix a DeprecationWarning

### DIFF
--- a/flask_theme/__init__.py
+++ b/flask_theme/__init__.py
@@ -24,7 +24,7 @@ from flask import (send_from_directory, render_template, json,
 from jinja2 import contextfunction
 from jinja2.loaders import FileSystemLoader, BaseLoader, TemplateNotFound
 from operator import attrgetter
-from werkzeug import cached_property
+from werkzeug.utils import cached_property
 try:
     from flask import Blueprint
 except ImportError:


### PR DESCRIPTION
Flask depends on Werkzeug library. Werkzeug has changed some way to import modules.
This PR removed this `DeprecationWarning`:
```
The import 'werkzeug.cached_property' is deprecated and will be removed in Werkzeug 1.0. Use 'from werkzeug.utils import cached_property' instead.
```